### PR TITLE
Add `traceparent`, `tracestate` headers from W3C Trace Context Spec

### DIFF
--- a/ExecutionContext.js
+++ b/ExecutionContext.js
@@ -40,6 +40,8 @@ class ExecutionContext {
       path: req.path,
       forwardedFor: req.header("X-Forwarded-For"),
       userAgent: req.header("User-Agent"),
+      traceparent: req.header("traceparent"),
+      tracestate: req.header("tracestate"),
       ...(this.#realClientIpHeader &&
         req.header(this.#realClientIpHeader) && {
           realIp: this.#realClientIpHeader,


### PR DESCRIPTION
The [`traceparent` header](https://www.w3.org/TR/trace-context/#traceparent-header) and [`tracestate` header](https://www.w3.org/TR/trace-context/#tracestate-header) are a part of the [W3C Trace Context spec](https://www.w3.org/TR/trace-context).